### PR TITLE
feat: Implement overlay auto-remove functionality (failed)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@supabase/supabase-js": "^2.46.2",
     "@tanstack/react-query": "^5.61.5",
     "@tanstack/react-query-devtools": "^5.62.0",
+    "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-kakao-maps-sdk": "^1.1.27",

--- a/src/components/features/SearchMap.jsx
+++ b/src/components/features/SearchMap.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useRestaurants from '../../hooks/useRestaurants';
 
@@ -54,11 +54,9 @@ const SearchMap = ({ selectedRestaurant }) => {
           const overlay = new kakao.maps.CustomOverlay({
             content: overlayContent,
             position: coords,
-            map: mapRef.current,
+            map: null,
             yAnchor: 1.4
           });
-
-          overlay.setMap(null); // 초기에는 표시하지 않음
 
           kakao.maps.event.addListener(marker, 'click', () => {
             overlay.setMap(mapRef.current);
@@ -82,14 +80,13 @@ const SearchMap = ({ selectedRestaurant }) => {
     if (!selectedRestaurant) return;
 
     const geocoder = new kakao.maps.services.Geocoder();
-    const mapContainer = document.getElementById('map');
 
     geocoder.addressSearch(selectedRestaurant.address, (result, status) => {
       if (status === kakao.maps.services.Status.OK) {
         const coords = new kakao.maps.LatLng(result[0].y, result[0].x);
 
-        mapRef.current.panTo(coords); // 지도 중심
-        mapRef.current.setLevel(2); // 지도 중심을 이동
+        mapRef.current.panTo(coords); // 지도 중심으로 이동
+        mapRef.current.setLevel(2); // 지도 확대
       }
     });
   }, [selectedRestaurant, kakao]);

--- a/src/components/ui/detail/RestaurantInfo.jsx
+++ b/src/components/ui/detail/RestaurantInfo.jsx
@@ -38,7 +38,7 @@ const RestaurantInfo = ({ id }) => {
         <p className="text-[12px]">{restaurants.chef_name} 셰프</p>
         <p className="text-[12px]">주소 : {restaurants.address}</p>
         <p className="text-[12px]">브레이크 타임: {restaurants.break_time ? restaurants.break_time : '없음'}</p>
-        {restaurants.day_off.length > 0 ? (
+        {restaurants.day_off?.length > 0 ? (
           <p className="text-[12px]">
             휴무 :
             {restaurants.day_off.map((day, index) => (

--- a/src/components/ui/search/Search.jsx
+++ b/src/components/ui/search/Search.jsx
@@ -26,7 +26,13 @@ const Search = () => {
             <input type="text" value={searchText} onChange={handleSearch} className="w-10/12 outline-none" />
             <button className="bg-search-icon w-[24px] h-[24px]"></button>
           </div>
-          <ul className="mt-[20px] flex flex-col gap-[20px] overflow-auto">
+          <ul
+            className="mt-[20px] flex flex-col gap-[20px] overflow-auto [&::-webkit-scrollbar]:w-2
+[&::-webkit-scrollbar-track]:bg-gray-100
+[&::-webkit-scrollbar-thumb]:bg-gray-300
+dark:[&::-webkit-scrollbar-track]:bg-neutral-700
+dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500"
+          >
             {filterdRestaurants().map((restaurant) => {
               return (
                 <SearchList key={restaurant.id} restaurant={restaurant} setSelectedRestaurant={setSelectedRestaurant} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2012,6 +2012,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -2600,12 +2605,10 @@ source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
-
 string-convert@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
   integrity sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==
-
 
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"


### PR DESCRIPTION
- Tried using `overlay.setMap(null)` from Kakao Map API to remove overlays
- Issue: Overlays were not properly removed despite using the provided method
- Considered assigning unique IDs to each overlay for forced removal, but deemed it unsuitable
- Plan: Redesign the implementation structure from scratch to achieve better functionality
